### PR TITLE
Fixes undefined references to LoadImage

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/memstate.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/memstate.hh
@@ -15,7 +15,9 @@
  */
 /// \file memstate.hh
 /// \brief Classes for keeping track of memory state during emulation
-
+#ifdef LoadImage
+#undef LoadImage
+#endif
 #ifndef __CPUI_MEMSTATE__
 #define __CPUI_MEMSTATE__
 


### PR DESCRIPTION
r2ghidra did not compile on windows because LoadImage was defined as LoadImageA from a windows header. Undefining it in several places including in the ghidra source solves the issue. I tried to keep the change out of ghidra and into r2ghidra, but that seemed not to work, somewhere from within the Ghidra source LoadImageA macro is loaded again.
